### PR TITLE
added schedule command with fake data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 config.json
+test_data/schedule_data.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
+.DS_Store
 
 # C extensions
 *.so

--- a/bot.py
+++ b/bot.py
@@ -21,6 +21,8 @@ from discord.ext.commands import Bot, Context
 
 import exceptions
 
+from test_data.test_data_generator import generate_random_schedule
+
 if not os.path.isfile(f"{os.path.realpath(os.path.dirname(__file__))}/config.json"):
     sys.exit("'config.json' not found! Please add it and try again.")
 else:
@@ -68,7 +70,7 @@ It is recommended to use slash commands and therefore not use prefix commands.
 
 If you want to use prefix commands, make sure to also enable the intent below in the Discord developer portal.
 """
-# intents.message_content = True
+intents.message_content = True
 
 bot = Bot(
     command_prefix=commands.when_mentioned_or(config["prefix"]),
@@ -160,6 +162,10 @@ async def on_ready() -> None:
     bot.logger.info(f"Python version: {platform.python_version()}")
     bot.logger.info(f"Running on: {platform.system()} {platform.release()} ({os.name})")
     bot.logger.info("-------------------")
+
+    # create a random schedule when bot starts
+    generate_random_schedule()
+
     status_task.start()
     if config["sync_commands_globally"]:
         bot.logger.info("Syncing commands globally...")

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -8,6 +8,7 @@ Version: 5.5.0
 
 import platform
 import random
+import json
 
 import aiohttp
 import discord
@@ -239,6 +240,36 @@ class General(commands.Cog, name="general"):
                         color=0xE02B2B,
                     )
                 await context.send(embed=embed)
+
+    @commands.hybrid_command(
+        name="schedule", description="List of next 5 events coming up."
+    )
+    @checks.not_blacklisted()
+    async def schedule(self, context: Context) -> None:
+        """
+        Check schedule of events.
+
+        :param context: The hybrid command context.
+        """
+        embed = discord.Embed(
+            title="Schedule",
+            description="List of next 5 events coming up:",
+            color=0x9C84EF,
+        )
+
+        with open(f"test_data/schedule_data.json", "r") as f:
+            schedule = json.load(f)
+            for event in schedule[:5]:
+                event_info = []
+                for info_key, info_value in event.items():
+                    event_info.append(f"{info_key} : {info_value}")
+                event_text = "\n".join(event_info)
+                embed.add_field(
+                    name=event["type"].capitalize(),
+                    value=f"```{event_text}```",
+                    inline=False,
+                )
+        await context.send(embed=embed)
 
 
 async def setup(bot):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp
 aiosqlite
 discord.py
+Faker

--- a/test_data/test_data_generator.py
+++ b/test_data/test_data_generator.py
@@ -1,0 +1,45 @@
+from faker import Faker
+import random
+import json
+
+
+def generate_random_schedule():
+    # Initialize Faker object
+    fake = Faker()
+    random.seed = 1
+
+    # Create list of event types and times
+    event_types = ["Workshop", "Keynote", "Panel", "Networking", "Activity"]
+    locations = ["Wondry Dungeons", "Wondry Ground Floor", "Seventh Tile from the Left"]
+
+    # Generate fake schedule where events are in order of date and time
+    schedule = []
+    for i in range(2):  # 2 days of events
+        num_of_events = random.randint(5, 10)  # random number of events per day
+        event_times = [
+            fake.time(pattern="%H:00:00", end_datetime=None)
+            for _ in range(num_of_events)
+        ]
+        event_times.sort()
+
+        for j in range(num_of_events):
+            event_type = random.choice(event_types)
+            start_time = event_times[j]
+            duration = random.choice([60, 90, 120])  # 60, 90, or 120 minute event
+            topic = fake.catch_phrase()
+            speaker = fake.name()
+            location = random.choice(locations)
+            event = {
+                "day": i + 1,
+                "type": event_type,
+                "start time": start_time,
+                "duration": duration,
+                "topic": topic,
+                "speaker": speaker,
+                "location": location,
+            }
+            schedule.append(event)
+
+    # Write schedule to JSON file
+    with open(f"test_data/schedule_data.json", "w") as outfile:
+        json.dump(schedule, outfile)


### PR DESCRIPTION
- Added `!schedule` command
- Changed intents.message_content = True on line 72 to allow prefix
- Created test_data directory for test_data_generator python file and the actual fake schedule (schedule_data.json)
- Used Faker to generate fake schedule ordered by date and time
- Added Faker to requirements

schedule.json is basically structured like this:
```
[{"day": 1, 
"type": "Networking", 
"start time": "01:00:00", 
"duration": 90, 
"topic": "Digitized needs-based toolset", 
"speaker": "Melissa Solomon", 
"location": "Seventh Tile from the Left"}, 
{"day": 1, "type": "Activity", 
"start time": "05:00:00", "duration": 90, 
"topic": "Realigned homogeneous website", 
"speaker": "Susan Arnold", 
"location": "Wondry Dungeons"}]
```

And the schedule command displays this:
<img width="360" alt="Screenshot 2023-03-29 at 1 34 06 AM" src="https://user-images.githubusercontent.com/52425323/228446350-de50e4f2-caaf-4264-924c-8feff5cf5430.png">